### PR TITLE
Fixes mattvenn/frequency_counter#2 (NOASSERT=1 corrupts waveform)

### DIFF
--- a/test/test_frequency_counter.py
+++ b/test/test_frequency_counter.py
@@ -49,7 +49,8 @@ async def test_all(dut):
 
         # give it 4 update periods to allow counters to adjust
         await ClockCycles(dut.clk, period * 4)
-        assert await read_segments(dut) == input_freq
+        displayed_freq = await read_segments(dut)
+        assert displayed_freq == input_freq
 
         # kill signal
         input_signal.kill()

--- a/test/test_seven_segment.py
+++ b/test/test_seven_segment.py
@@ -50,4 +50,5 @@ async def test_seven_segment(dut):
             await ClockCycles(dut.clk, 1)
             dut.load.value = 0
             await ClockCycles(dut.clk, 2) # have to wait a couple of cycles for flops
-            assert await read_segments(dut) == tens * 10 + units
+            displayed_freq = await read_segments(dut)
+            assert displayed_freq == tens * 10 + units


### PR DESCRIPTION
This should do the trick. `read_segments()` will now be called no matter whether assertions are disabled or not.